### PR TITLE
Support restarting multi process programs by allowing regex in process name

### DIFF
--- a/superfsmon/superfsmon.py
+++ b/superfsmon/superfsmon.py
@@ -135,8 +135,15 @@ def requires_restart(proc):
     statename = proc['statename']
     pid = proc['pid']
 
+    programs_regex = f'^(({")|(".join(args.program)}))$' if args.program else None
+    groups_regex = f'^(({")|(".join(args.group)}))$' if args.group else None
+
     return ((statename == 'STARTING' or statename == 'RUNNING') and
-            (args.any or name in args.program or group in args.group) and
+            (
+              args.any
+              or (programs_regex and re.search(programs_regex, name))
+              or (groups_regex and re.search(groups_regex, group))
+            ) and
             pid != os.getpid())
 
 


### PR DESCRIPTION
With the current way of finding processes that needs to be restarted on code change, services with multiprocessing enabled are not restarted as the child processes in that case will have variable program names.

This pull request allows program and group argument  to support regex input also.

for eg.
```
[program:abcd]
numprocs=4
numprocs_start=01
process_name=%(program_name)s_%(process_num)02d
```